### PR TITLE
Added (decompressor == null) check

### DIFF
--- a/java/hadoop-4mc/src/main/java/com/hadoop/compression/fourmc/FourMcInputStream.java
+++ b/java/hadoop-4mc/src/main/java/com/hadoop/compression/fourmc/FourMcInputStream.java
@@ -337,6 +337,9 @@ public class FourMcInputStream extends BlockDecompressorStream {
 
     @Override
     public void close() throws IOException {
+        if ( decompressor == null ) {
+            return;
+        }
         byte[] b = new byte[4096];
         while (!decompressor.finished()) {
           decompressor.decompress(b, 0, b.length);


### PR DESCRIPTION
Added (decompressor == null) check in FourMcInputStream.java.  This avoids a nullPointerException if .close() is called more than once.
